### PR TITLE
Supporting WebGPU backend

### DIFF
--- a/.idea/cross-platform-renderer.iml
+++ b/.idea/cross-platform-renderer.iml
@@ -6,6 +6,7 @@
       <sourceFolder url="file://$MODULE_DIR$/bin/desktop/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/bin/wasm/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/core/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/bin/web/src" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -40,10 +40,25 @@ Run `cargo run`. By default the desktop crate is build.
 
 Run `cargo apk run -p android-build` optionally with the flag `--target <triple>` for explicit target selection.
 
-### Web
+### Web - WebGL2 Backend
 
 Run `cd bin/web/`
 
 Run `trunk serve`
 
 Trunk is now serving app under `http://localhost:8080`
+
+## Using WebGPU as the Web Backend
+
+Change the limits in the device descriptor in `core/src/lib.rs` from `wgpu::Limits::downlevel_webgl2_defaults()` to `wgpu::Limits::default()`.
+
+Remove the `webgl` feature from `core/Cargo.toml`.
+
+Set the `--cfg=web_sys_unstable_apis` rust flag.
+This can be done by setting `RUSTFLAGS=--cfg=web_sys_unstable_apis`, or by creating a `.cargo/config` file with
+```
+[build]
+rustflags = [
+    "--cfg=web_sys_unstable_apis"
+]
+```

--- a/bin/web/Cargo.toml
+++ b/bin/web/Cargo.toml
@@ -9,3 +9,5 @@ edition = "2021"
 renderer-core = { path = "../../core" }
 console_log = "0.2"
 log = "0.4"
+wasm-bindgen-futures = "0.4"
+console_error_panic_hook = "0.1"

--- a/bin/web/Trunk.toml
+++ b/bin/web/Trunk.toml
@@ -1,0 +1,2 @@
+[watch]
+watch = ["../../core", "./src"]

--- a/bin/web/src/main.rs
+++ b/bin/web/src/main.rs
@@ -1,7 +1,9 @@
 use log::Level;
-use renderer_core::start;
+use renderer_core::run;
+use wasm_bindgen_futures;
 
 fn main() {
     console_log::init_with_level(Level::Warn).expect("Log init failed");
-    start();
+    std::panic::set_hook(Box::new(console_error_panic_hook::hook));
+    wasm_bindgen_futures::spawn_local(run());
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -9,7 +9,7 @@ pub fn start() {
     pollster::block_on(run());
 }
 
-async fn run() {
+pub async fn run() {
     let event_loop = EventLoop::new();
     let window = match WindowBuilder::new().build(&event_loop) {
         Ok(window) => window,


### PR DESCRIPTION
Better support for the WebGPU backend as well as a few other quality-of-life tweaks.
 - Added `bin/web/src` to the `.idea/cross-platform-renderer.iml` file.
 - Added information to the readme explaining how to get the WebGPU backend running.
 - Added `console_error_panic_hook` to properly display errors when running on web.
 - Added a Trunk.toml file to add `core/` to the watch list, enabling hot reloading.
 - Added `wasm-bindgen-futures` and used it to `spawn_local` when on web, for easier WebGPU backend compatibility.